### PR TITLE
PI-2361 Only include high-confidence risks in Zap report

### DIFF
--- a/.zap/autorun.yml
+++ b/.zap/autorun.yml
@@ -64,9 +64,25 @@ jobs:
     parameters:
       reportDir: "zap-report"
       reportFile: "index.html"
+    risks:
+      - high
+      - medium
+      - low
+    confidences:
+      - high
+    sites:
+      - "https://manage-a-supervision-dev.hmpps.service.justice.gov.uk"
   - name: "JSON Report"
     type: report
     parameters:
       template: "traditional-json"
       reportDir: "zap-report"
       reportFile: "report.json"
+    risks:
+      - high
+      - medium
+      - low
+    confidences:
+      - high
+    sites:
+      - "https://manage-a-supervision-dev.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
Also filters output to only include reports for the MAS site, to exclude responses from HMPPS Auth