### PR TITLE
PI-2420 Mark credit card numbers as false positive in ZAP scan

### DIFF
--- a/.zap/autorun.yml
+++ b/.zap/autorun.yml
@@ -54,6 +54,12 @@ jobs:
       type: "standalone"
       engine: ""
       name: "traverse.js"
+  - type: alertFilter
+    alertFilters:
+      - ruleId: 10062 # PII Disclosure - https://www.zaproxy.org/docs/alerts/10062/
+        newRisk: False Positive
+        evidence: "^[0-9]{16}$" # Script tag "nonce" attribute can be mistaken for a credit card number
+        evidenceRegex: true
   - type: activeScan
     parameters:
       context: "HMPPSAuth"

--- a/.zap/autorun.yml
+++ b/.zap/autorun.yml
@@ -57,9 +57,7 @@ jobs:
   - type: alertFilter
     alertFilters:
       - ruleId: 10062 # PII Disclosure - https://www.zaproxy.org/docs/alerts/10062/
-        newRisk: False Positive
-        evidence: "^[0-9]{16}$" # Script tag "nonce" attribute can be mistaken for a credit card number
-        evidenceRegex: true
+        newRisk: False Positive # Script tag "nonce" attribute can be mistaken for a credit card number
   - type: activeScan
     parameters:
       context: "HMPPSAuth"


### PR DESCRIPTION
We don't hold financial information, so very unlikely to be a real issue